### PR TITLE
Bump version to 1.10.0

### DIFF
--- a/Skip.env
+++ b/Skip.env
@@ -11,7 +11,7 @@ PRODUCT_NAME = PhotoExhibition
 PRODUCT_BUNDLE_IDENTIFIER = me.fromkk.PhotoExhibition
 
 // The semantic version of the app
-MARKETING_VERSION = 1.9.0
+MARKETING_VERSION = 1.10.0
 
 // The build number specifying the internal app version
 CURRENT_PROJECT_VERSION = 343

--- a/Versions.env
+++ b/Versions.env
@@ -1,5 +1,5 @@
 // The semantic version of the app
-MARKETING_VERSION = 1.9.0
+MARKETING_VERSION = 1.10.0
 
 // The build number specifying the internal app version
 CURRENT_PROJECT_VERSION = 343


### PR DESCRIPTION
## Summary
- update Skip.env and Versions.env marketing version to 1.10.0

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684272197e1883218fa78d2b38fb7884