### PR TITLE
Show icon when photo lacks text

### DIFF
--- a/Sources/PhotoExhibition/Views/Exhibitions/Detail/ExhibitionDetailView.swift
+++ b/Sources/PhotoExhibition/Views/Exhibitions/Detail/ExhibitionDetailView.swift
@@ -1252,7 +1252,18 @@ struct PhotoGridItem: View {
       }
       .buttonStyle(.plain)
 
-      // タイトルがある場合は小さなインジケータを表示
+      // 主催者向け: タイトル・説明が無い場合はアイコンを表示
+      if isOrganizer && photo.title == nil && photo.description == nil {
+        Image(
+          systemName: SystemImageMapping.getIconName(from: "exclamationmark.triangle")
+        )
+        .font(.caption)
+        .padding(4)
+        .foregroundStyle(.white)
+        .background(Circle().fill(Color.black.opacity(0.5)))
+        .padding(4)
+      }
+      // タイトルか説明がある場合はインジケータを表示
       if photo.title != nil || photo.description != nil {
         #if SKIP
           Image("text.document", bundle: .module)


### PR DESCRIPTION
## Summary
- mark photos without title or description using an icon for organizers

## Testing
- `swift test --list-tests` *(fails: Tool `skip` is not supported on the target platform)*

------
https://chatgpt.com/codex/tasks/task_e_684a1c6f0f308321a67eb36a5baaaab9