### PR TITLE
タイトル・説明文がない時に警告アイコンを表示する

### DIFF
--- a/Skip.env
+++ b/Skip.env
@@ -14,7 +14,7 @@ PRODUCT_BUNDLE_IDENTIFIER = me.fromkk.PhotoExhibition
 MARKETING_VERSION = 1.10.0
 
 // The build number specifying the internal app version
-CURRENT_PROJECT_VERSION = 352
+CURRENT_PROJECT_VERSION = 353
 
 // The package name for the Android entry point, referenced by the AndroidManifest.xml
 ANDROID_PACKAGE_NAME = photo.exhibition

--- a/Sources/PhotoExhibition/Resources/Localizable.xcstrings
+++ b/Sources/PhotoExhibition/Resources/Localizable.xcstrings
@@ -738,6 +738,16 @@
         }
       }
     },
+    "No title" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイトルがありません"
+          }
+        }
+      }
+    },
     "No title and description" : {
       "localizations" : {
         "ja" : {

--- a/Sources/PhotoExhibition/Views/Exhibitions/Detail/ExhibitionDetailView.swift
+++ b/Sources/PhotoExhibition/Views/Exhibitions/Detail/ExhibitionDetailView.swift
@@ -1252,6 +1252,11 @@ struct PhotoGridItem: View {
           .clipShape(RoundedRectangle(cornerRadius: 8))
       }
       .buttonStyle(.plain)
+      .accessibilityLabel(Text(
+        photo.title ??
+        photo.description ??
+        String(localized: "No title", bundle: .module)
+      ))
 
       // 主催者向け: タイトル・説明が無い場合はアイコンを表示
       if isOrganizer && photo.title == nil && photo.description == nil {

--- a/Versions.env
+++ b/Versions.env
@@ -2,4 +2,4 @@
 MARKETING_VERSION = 1.10.0
 
 // The build number specifying the internal app version
-CURRENT_PROJECT_VERSION = 352
+CURRENT_PROJECT_VERSION = 353


### PR DESCRIPTION
タイトル・説明文をなるべく入力してもらうため