### PR TITLE
Optimize image caching

### DIFF
--- a/Sources/PhotoExhibitionModel/Clients/StorageImageCache.swift
+++ b/Sources/PhotoExhibitionModel/Clients/StorageImageCache.swift
@@ -30,15 +30,9 @@ public final actor StorageImageCache: StorageImageCacheProtocol {
   /// 画像URLを取得する（キャッシュがあればキャッシュから、なければStorageClientから）
   public func getImageURL(for path: String) async throws -> URL {
     // キャッシュにあればそれを返す
-    if let cachedURL = cache[path] {
-      // ファイルが存在するか確認
-      if fileManager.fileExists(atPath: cachedURL.path) {
-        return cachedURL
-      }
+    if let cachedURL = cache[path], fileManager.fileExists(atPath: cachedURL.path) {
+      return cachedURL
     }
-
-    // キャッシュになければStorageClientからダウンロードしてローカルに保存
-    let storageURL = try await storageClient.url(path)
 
     // ローカルにファイルが保存済みか確認
     let cacheDirectory = try getCacheDirectory()
@@ -51,7 +45,8 @@ public final actor StorageImageCache: StorageImageCacheProtocol {
       return fileURL
     }
 
-    // ダウンロードして保存
+    // ローカルになければStorageClientからダウンロードしてローカルに保存
+    let storageURL = try await storageClient.url(path)
     let localURL = try await downloadAndSaveImage(from: storageURL, for: path)
 
     // キャッシュに保存

--- a/Sources/Viewer/Clients/ImageCacheClient.swift
+++ b/Sources/Viewer/Clients/ImageCacheClient.swift
@@ -27,15 +27,9 @@ public final actor StorageImageCache: StorageImageCacheProtocol {
   /// 画像URLを取得する（キャッシュがあればキャッシュから、なければStorageClientから）
   public func getImageURL(for path: String) async throws -> URL {
     // キャッシュにあればそれを返す
-    if let cachedURL = cache[path] {
-      // ファイルが存在するか確認
-      if fileManager.fileExists(atPath: cachedURL.path) {
-        return cachedURL
-      }
+    if let cachedURL = cache[path], fileManager.fileExists(atPath: cachedURL.path) {
+      return cachedURL
     }
-
-    // キャッシュになければStorageClientからダウンロードしてローカルに保存
-    let storageURL = try await storageClient.url(path)
 
     // ローカルにファイルが保存済みか確認
     let cacheDirectory = try getCacheDirectory()
@@ -48,7 +42,8 @@ public final actor StorageImageCache: StorageImageCacheProtocol {
       return fileURL
     }
 
-    // ダウンロードして保存
+    // ローカルになければStorageClientからダウンロードしてローカルに保存
+    let storageURL = try await storageClient.url(path)
     let localURL = try await downloadAndSaveImage(from: storageURL, for: path)
 
     // キャッシュに保存


### PR DESCRIPTION
## Summary
- avoid fetching download URLs when the image is already cached on disk
- check the cache directory before requesting a new download URL

## Testing
- `swift build` *(fails: Tool 'skip' is not supported on the target platform)*

------
https://chatgpt.com/codex/tasks/task_e_684d7982b7608321b460d938532d9274