### PR TITLE
Enable link detection in exhibition descriptions

### DIFF
--- a/Sources/PhotoExhibition/Extensions/String+LinkDetection.swift
+++ b/Sources/PhotoExhibition/Extensions/String+LinkDetection.swift
@@ -1,0 +1,29 @@
+// This link detection relies on APIs that are unavailable in Skip builds.
+#if SKIP
+import Foundation
+
+extension String {
+  /// Returns a plain attributed string without link attributes when built for Skip.
+  var linkified: AttributedString { AttributedString(self) }
+}
+#else
+import Foundation
+
+extension String {
+  /// Returns an `AttributedString` where URL strings are converted to tappable links.
+  var linkified: AttributedString {
+    var attributed = AttributedString(self)
+    let types = NSTextCheckingResult.CheckingType.link.rawValue
+    if let detector = try? NSDataDetector(types: types) {
+      let nsRange = NSRange(startIndex..<endIndex, in: self)
+      for match in detector.matches(in: self, options: [], range: nsRange) {
+        guard let url = match.url,
+          let range = Range(match.range, in: self)
+        else { continue }
+        attributed[range].link = url
+      }
+    }
+    return attributed
+  }
+}
+#endif

--- a/Sources/PhotoExhibition/Views/Exhibitions/Detail/ExhibitionDetailView.swift
+++ b/Sources/PhotoExhibition/Views/Exhibitions/Detail/ExhibitionDetailView.swift
@@ -736,7 +736,7 @@ struct ExhibitionDetailView: View {
                 .fontWeight(.bold)
 
               if let description = store.exhibition.description {
-                Text(description)
+                Text(description.linkified)
                   .font(.body)
                   .padding(.top, 4)
               }

--- a/Sources/PhotoExhibition/Views/Exhibitions/ExhibitionRow.swift
+++ b/Sources/PhotoExhibition/Views/Exhibitions/ExhibitionRow.swift
@@ -65,7 +65,7 @@ struct ExhibitionRow: View {
         }
 
         if let description = exhibition.description {
-          Text(description)
+          Text(description.linkified)
             .font(.subheadline)
             .foregroundStyle(.secondary)
             .lineLimit(2)

--- a/Sources/PhotoExhibition/Views/Exhibitions/OrganizerProfileView.swift
+++ b/Sources/PhotoExhibition/Views/Exhibitions/OrganizerProfileView.swift
@@ -237,7 +237,7 @@ struct OrganizerExhibitionRow: View {
           .frame(maxWidth: .infinity, alignment: .leading)
 
         if let description = exhibition.description {
-          Text(description)
+          Text(description.linkified)
             .font(.subheadline)
             .foregroundStyle(.secondary)
             .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary
- add `String.linkified` helper to detect URLs in text
- use the helper so exhibition descriptions show tappable links
- skip link detection logic when building with Skip

## Testing
- `swift --version`
- `swift build` *(fails to complete: tool `skip` unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68572e2f490c8321ae6f60e3109bc047