### PR TITLE
Bump app version to 1.11.1

### DIFF
--- a/Skip.env
+++ b/Skip.env
@@ -11,7 +11,7 @@ PRODUCT_NAME = PhotoExhibition
 PRODUCT_BUNDLE_IDENTIFIER = me.fromkk.PhotoExhibition
 
 // The semantic version of the app
-MARKETING_VERSION = 1.11.0
+MARKETING_VERSION = 1.11.1
 
 // The build number specifying the internal app version
 CURRENT_PROJECT_VERSION = 362

--- a/Versions.env
+++ b/Versions.env
@@ -1,5 +1,5 @@
 // The semantic version of the app
-MARKETING_VERSION = 1.11.0
+MARKETING_VERSION = 1.11.1
 
 // The build number specifying the internal app version
 CURRENT_PROJECT_VERSION = 362


### PR DESCRIPTION
## Summary
- update `MARKETING_VERSION` in `Versions.env`
- update `MARKETING_VERSION` in `Skip.env`

## Testing
- `swift test --disable-sandbox` *(fails: Tool 'skip' is not supported on the target platform)*

------
https://chatgpt.com/codex/tasks/task_e_68574983e150832191f86bd72c8e9031