### PR TITLE
Update CI to skip gradle

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -5,3 +5,6 @@ defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
 defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -bool YES
 
 brew install skiptools/skip/skip
+
+# Disable Skip during CI builds by preventing gradle from running
+echo "SKIP_ACTION = none" >> Darwin/PhotoExhibition.xcconfig


### PR DESCRIPTION
## Summary
- disable Skip build in CI by writing `SKIP_ACTION = none` to PhotoExhibition.xcconfig

## Testing
- `swift test -l` *(fails: Tool 'skip' is not supported on the target platform)*

------
https://chatgpt.com/codex/tasks/task_e_685751eb1088832190f9866e9cc67e5d